### PR TITLE
Use polars API to add random frequencies in `add_frequency()`

### DIFF
--- a/src/phenotype2phenopacket/utils/phenopacket_utils.py
+++ b/src/phenotype2phenopacket/utils/phenopacket_utils.py
@@ -150,15 +150,12 @@ class SyntheticPatientGenerator:
 
     def add_frequency(self):
         """Add random frequency to annotations without one defined."""
-        updated_df = []
-        for row in self.disease_df.rows(named=True):
-            if row["frequency"] is None:
-                synthetic_frequency = self.secret_rand.uniform(0, 1)
-                row["frequency"] = synthetic_frequency
-                updated_df.append(row)
-            elif row["frequency"] is not None:
-                updated_df.append(row)
-        return pl.from_dicts(updated_df)
+        return self.disease_df.with_columns([
+            pl.when(self.disease_df['frequency'].is_null())
+            .then(pl.lit(self.secret_rand.uniform(0, 1)))
+            .otherwise(self.disease_df['frequency'])
+            .alias('frequency')
+        ])
 
     def get_onset_range(self):
         """Get the onset range from a set of annotations for a disease."""


### PR DESCRIPTION
In the `main` branch of phenotypes2phenopacket (currently e170c0eaab2070cda4d6545f677858307c4b5449), generating synthetic patient data from the current HPOA at `http://purl.obolibrary.org/obo/hp/hpoa/phenotype.hpoa` like this:
`p2p create --phenotype-annotation ./phenotype.hpoa --output-dir test_ppk`

generates this error:

```
Traceback (most recent call last):
  File "/usr/local/bin/p2p", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/phenotype2phenopacket/cli_create.py", line 40, in create_synthetic_patient_command
    create_synthetic_patients(phenotype_annotation_df, num_disease, output_dir)
  File "/usr/local/lib/python3.10/dist-packages/phenotype2phenopacket/create/create.py", line 43, in create_synthetic_patients
    create_synthetic_patient_phenopacket(
  File "/usr/local/lib/python3.10/dist-packages/phenotype2phenopacket/create/create.py", line 21, in create_synthetic_patient_phenopacket
    patient_terms = synthetic_patient_generator.patient_term_annotation_set()
  File "/usr/local/lib/python3.10/dist-packages/phenotype2phenopacket/utils/phenopacket_utils.py", line 332, in patient_term_annotation_set
    patient_terms = self.get_patient_terms()
  File "/usr/local/lib/python3.10/dist-packages/phenotype2phenopacket/utils/phenopacket_utils.py", line 251, in get_patient_terms
    self.shuffle_dataframe(self.add_frequency()), self.get_number_of_terms()
  File "/usr/local/lib/python3.10/dist-packages/phenotype2phenopacket/utils/phenopacket_utils.py", line 161, in add_frequency
    return pl.from_dicts(updated_df)
  File "/usr/local/lib/python3.10/dist-packages/polars/convert.py", line 179, in from_dicts
    return pl.DataFrame(
  File "/usr/local/lib/python3.10/dist-packages/polars/dataframe/frame.py", line 368, in __init__
    self._df = sequence_to_pydf(
  File "/usr/local/lib/python3.10/dist-packages/polars/utils/_construction.py", line 805, in sequence_to_pydf
    return _sequence_to_pydf_dispatcher(
  File "/usr/lib/python3.10/functools.py", line 889, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/usr/local/lib/python3.10/dist-packages/polars/utils/_construction.py", line 1021, in _sequence_of_dict_to_pydf
    pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
exceptions.ComputeError: could not append {:?} to the builder; make sure that all rows have the same schema or consider increasing `schema_inference_length`
```

[This](https://colab.research.google.com/drive/1DW2Rsl_yXPo9-3Q3sOWUEu8mkfwQ79qZ?usp=sharing) colab notebook should reproduce this. This seems to be an issue converting `self.disease_df` from a `dict` back to a Polars df after replacing `None` frequencies with random values. This PR uses the Polars API to do this, and seems to solve the problem