### PR TITLE
Check for no parent in get_parents_of_terms()

### DIFF
--- a/src/phenotype2phenopacket/utils/phenopacket_utils.py
+++ b/src/phenotype2phenopacket/utils/phenopacket_utils.py
@@ -479,7 +479,7 @@ class SyntheticPatientGenerator:
             parents = self.ontology.hierarchical_parents(term_id)
             parent = self.secret_rand.choice(parents)
             if not parents:
-                warnings.warn(f"No parents found for term {term}")
+                warnings.warn(f"No parents found for term {term}", stacklevel=2)
                 return phenotype_entry
             rels = self.ontology.entity_alias_map(parent)
             term = "".join(rels[(list(rels.keys())[0])])

--- a/src/phenotype2phenopacket/utils/phenopacket_utils.py
+++ b/src/phenotype2phenopacket/utils/phenopacket_utils.py
@@ -1,6 +1,7 @@
 import re
 import secrets
 import signal
+import warnings
 from copy import copy
 from dataclasses import dataclass
 from fractions import Fraction
@@ -477,6 +478,9 @@ class SyntheticPatientGenerator:
         for _i in range(steps):
             parents = self.ontology.hierarchical_parents(term_id)
             parent = self.secret_rand.choice(parents)
+            if not parents:
+                warnings.warn(f"No parents found for term {term}")
+                return phenotype_entry
             rels = self.ontology.entity_alias_map(parent)
             term = "".join(rels[(list(rels.keys())[0])])
             if (


### PR DESCRIPTION
When running phenotype2phenopacket, I'm seeing an `IndexError` [here](https://github.com/yaseminbridges/phenotype2phenopacket/blob/2a73048fc15e921a7d11af028bac125446c7ecc0/src/phenotype2phenopacket/utils/phenopacket_utils.py#L479) for [the HPO term _Cleft lip_](https://hpo.jax.org/app/browse/term/HP:0410030)
because it isn't _Abnormality of_ and also does not have a parent (notice it's parent is "Artificial root"/`Owl:Thing`)

This PR check for no parent and moves on after emitting this warning:
`UserWarning: No parents found for term Cleft lip`