### PR TITLE
Remove dependency on SIGALARM 

### DIFF
--- a/src/phenotype2phenopacket/add/add_genes.py
+++ b/src/phenotype2phenopacket/add/add_genes.py
@@ -61,9 +61,11 @@ def add_genes(
             omim_disease_phenotype_gene_map=filtered_disease_pg,
             gene_identifier_updater=gene_identifier_updater,
         )
-        write_phenopacket(
-            phenopacket_with_genes, output_dir.joinpath(phenopacket_path.name)
-        ) if phenopacket_with_genes is not None else None
+        (
+            write_phenopacket(phenopacket_with_genes, output_dir.joinpath(phenopacket_path.name))
+            if phenopacket_with_genes is not None
+            else None
+        )
 
 
 def add_genes_to_directory(phenopacket_dir: Path, disease_pg: pl.DataFrame, output_dir: Path):

--- a/src/phenotype2phenopacket/utils/phenopacket_utils.py
+++ b/src/phenotype2phenopacket/utils/phenopacket_utils.py
@@ -596,9 +596,9 @@ class PhenotypeAnnotationToPhenopacketConverter:
             age = None
         return Individual(
             id="patient1",
-            time_at_last_encounter=TimeElement(age=Age(iso8601duration=f"P{age}Y"))
-            if age is not None
-            else None,
+            time_at_last_encounter=(
+                TimeElement(age=Age(iso8601duration=f"P{age}Y")) if age is not None else None
+            ),
         )
 
     def create_onset(self, phenotype_annotation_entry: dict) -> TimeElement:
@@ -865,9 +865,9 @@ class PhenopacketInterpretationExtender:
             )
             return GenomicInterpretation(
                 subject_or_biosample_id="patient1",
-                interpretation_status=4
-                if gene_to_phenotype_entry["disease_name"].startswith("?") is False
-                else 0,
+                interpretation_status=(
+                    4 if gene_to_phenotype_entry["disease_name"].startswith("?") is False else 0
+                ),
                 gene=GeneDescriptor(
                     value_id=gene_identifier_updater.find_identifier(gene_symbol),
                     symbol=gene_symbol,

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -868,14 +868,17 @@ class TestSyntheticPatientGenerator(unittest.TestCase):
     def test_alter_term_specificity_less_specific(self):
         mock_return_value = 0.4
         mock_steps_value = 1
-        with patch.object(
-            self.synthetic_patient_generator,
-            "return_less_or_more_specific",
-            return_value=mock_return_value,
-        ), patch.object(
-            self.synthetic_patient_generator,
-            "get_number_of_steps_for_randomisation",
-            side_effect=[mock_steps_value, mock_steps_value],
+        with (
+            patch.object(
+                self.synthetic_patient_generator,
+                "return_less_or_more_specific",
+                return_value=mock_return_value,
+            ),
+            patch.object(
+                self.synthetic_patient_generator,
+                "get_number_of_steps_for_randomisation",
+                side_effect=[mock_steps_value, mock_steps_value],
+            ),
         ):
             altered_phenotype = self.synthetic_patient_generator.alter_term_specificity(
                 [],
@@ -918,14 +921,17 @@ class TestSyntheticPatientGenerator(unittest.TestCase):
     def test_alter_term_specificity_more_specific(self):
         mock_return_value = 0.8
         mock_steps_value = 1
-        with patch.object(
-            self.synthetic_patient_generator,
-            "return_less_or_more_specific",
-            return_value=mock_return_value,
-        ), patch.object(
-            self.synthetic_patient_generator,
-            "get_number_of_steps_for_randomisation",
-            side_effect=[mock_steps_value, mock_steps_value],
+        with (
+            patch.object(
+                self.synthetic_patient_generator,
+                "return_less_or_more_specific",
+                return_value=mock_return_value,
+            ),
+            patch.object(
+                self.synthetic_patient_generator,
+                "get_number_of_steps_for_randomisation",
+                side_effect=[mock_steps_value, mock_steps_value],
+            ),
         ):
             altered_phenotype = self.synthetic_patient_generator.alter_term_specificity(
                 [


### PR DESCRIPTION
Removed the use of `SIGALARM` for timeout on a function as this only works with Linux systems. No nice workaround